### PR TITLE
Changed JSON datatype of 'changed' (and 'failed') attribute back to boolean, as handlers were failing to fire when this was a string

### DIFF
--- a/yum2
+++ b/yum2
@@ -25,34 +25,14 @@
 #set -x
 
 function exit_success() {
-  print_json 'msg' 'changed'
+  echo "{\"changed\": $changed, \"msg\": \"$msg\"}"
   exit 0
 }
 
 function exit_failed() {
-  print_json 'failed' 'msg'
+  echo "{\"failed\": $failed, \"msg\": \"$msg\"}"
   exit 1
 }
-
-function print_json() {
-  echo '{'
-  coma=""
-
-  for arg in $@
-  do
-    [[ -n "${!arg}" ]] && val="${!arg}" || continue
-
-    if echo $val | grep -q "^\["; then
-      echo "   ${coma} \"${arg}\": ${val}"
-    else
-      echo "   ${coma} \"${arg}\": \"${val}\""
-    fi
-
-    [[ -z "${coma}" ]] && coma=","
-  done
-  echo '}'
-}
-
 
 source ${1}
 
@@ -61,7 +41,7 @@ YUM_REPOS=/etc/yum.repos.d
 # Check the correctness of the input first
 
 if [[ -z "${name}" ]]; then
-  failed="True"
+  failed="true"
   msg="Please, specify the name of the package to deal with"
 
   exit_failed
@@ -73,7 +53,7 @@ case $state in
   'present'|'latest'|'absent'|'installed')
     ;;
   *)
-    failed="True"
+    failed="true"
     msg="Please, specify the correct state: present, absent or latest"
     exit_failed
     ;;
@@ -83,13 +63,13 @@ if [[ ! -z "${enablerepo}" || ! -z "${disablerepo}" ]]; then
   for i in ${enablerepo//,/ } ${disablerepo//,/ }
   do
     if ! grep -q "\[$i\]" $YUM_REPOS/*.repo; then
-      failed="True"
+      failed="true"
       failed_repos="$failed_repos $i"
     fi
   done
 
   if [[ ! -z "${failed}" ]]; then
-    failed="True"
+    failed="true"
     msg="The following repos could not be found in yum configuration in $YUM_REPOS directory:${failed_repos}"
     exit_failed
   fi
@@ -179,9 +159,9 @@ if [[ ! -z "${to_install}" ]]; then
   if [[ ! -z "$x" ]]; then
     msg="$x packages has been failed for installation;"
     
-    [[ "${x}" != "${to_install}" ]] && changed="True" || failed="True"
+    [[ "${x}" != "${to_install}" ]] && changed="true" || failed="true"
   else
-    changed="True"
+    changed="true"
   fi
 fi
 
@@ -193,7 +173,7 @@ if [[ ! -z "${to_update}" ]]; then
   if ${cmd2} ${to_update} 2>&1 &>/dev/null; then
     version_now="$(rpmquery --queryformat=\"%{VERSION}-%{RELEASE}\" ${to_update})"
 
-    [[ "${version}" != "${version_now}" ]] && changed="True"
+    [[ "${version}" != "${version_now}" ]] && changed="true"
   fi
 fi
 
@@ -201,7 +181,7 @@ if [[ ! -z "${to_remove}" ]]; then
   cmd="$cmd remove"
   x=""
 
-  ${cmd} ${to_remove} 2>&1 &>/dev/null && changed="True"
+  ${cmd} ${to_remove} 2>&1 &>/dev/null && changed="true"
 
   for i in "${to_remove}"
   do
@@ -210,7 +190,7 @@ if [[ ! -z "${to_remove}" ]]; then
     if [[ ! -z "${x}" ]]; then
       msg="$x packages has been failed to remove;"
 
-      [[ "${x}" == "${to_remove}" ]] && failed="True"
+      [[ "${x}" == "${to_remove}" ]] && failed="true"
     fi
   done
 fi
@@ -223,4 +203,3 @@ if [[ -z ${failed} ]]; then
 else
   exit_failed
 fi
-


### PR DESCRIPTION
Hi there,

We have moved to the latest version of yum2 and have encountered an issue where ansible handlers were not being fired even when a task reports a change. We have tracked this down to the fact that yum2 reports a change in JSON as: _"changed" : "True"_ however the previous version of yum2 we used reported the change as _"changed" : true_ i.e. the datatype of the changed attribute has changed from boolean to string and this prevents task handlers from firing. Indeed, changing the datatype back to boolean here fixes this issue for us. I realise that this pull request does away with the generic JSON function you wrote, as it is in here that anything that is not an array is assumed to be a string. If you preferred to replace this with a generic function that handled other JSON datatypes then we would be happy to take use that too.

Cheers,
Hayden
