### PR TITLE
Use 'update-to' for upgrading packages

### DIFF
--- a/yum2
+++ b/yum2
@@ -195,7 +195,8 @@ if [[ ! -z "${to_install}" ]]; then
 fi
 
 if [[ ! -z "${to_update}" ]]; then
-  cmd2="${cmd} update"
+  # this respect globs with version numbers
+  cmd2="${cmd} update-to"
 
   version="$(rpmquery --queryformat=\"%{VERSION}-%{RELEASE}\" ${to_update})"
 


### PR DESCRIPTION
This allows for globs to be used to limit the upgrade to a particular
version range.

Assuming the following packages exist:

- foo-1.0.0
- foo-1.0.1
- foo-2.0.0

The following behaviour can be expected:

- foo-1.0.0 is upgraded to foo-2.0.0 with 'yum update foo-1.0.*'
- foo-1.0.0 is upgraded to foo-1.0.1 with 'yum update-to foo-1.0.*'
- foo-1.0.0 is upgraded to foo-2.0.0 with 'yum update-to foo'

Using this alternative command seems to only offer advantages.